### PR TITLE
Update test-coverage CI

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -16,7 +16,7 @@ jobs:
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
@@ -53,5 +53,5 @@ jobs:
           fi
 
       - name: Test coverage
-        run: covr::coveralls(token = Sys.getenv("COVERALLS_TOKEN"), type = c("tests", "examples"))
+        run: print(nchar(Sys.getenv("CODECOV_TOKEN")));covr::codecov(token = Sys.getenv("CODECOV_TOKEN"), type = c("tests", "examples"))
         shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,9 +1,14 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -19,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -37,7 +42,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: covr, local::.
+          extra-packages: any::covr, any::xml2
+          needs: coverage
 
       - uses: julia-actions/setup-julia@v1
         with:
@@ -53,5 +59,33 @@ jobs:
           fi
 
       - name: Test coverage
-        run: print(nchar(Sys.getenv("CODECOV_TOKEN")));covr::codecov(token = Sys.getenv("CODECOV_TOKEN"), type = c("tests", "examples"))
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package


### PR DESCRIPTION
As an attempting at fixing the code-coverage GHA, this PR reverts back to using codecov (which has better support in {covr} than coveralls) and updates the action yaml (by consulting the output of `usethis::use_github_action("test-coverage")`).

Ref: https://github.com/r-lib/actions/issues/834